### PR TITLE
AU-2123: Update version constrains for D10, run PHPCS fixes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,19 @@
     },
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
-    "require": {}
+    "require": {},
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://repository.drupal.hel.ninja"
+        },
+        {
+            "type": "composer",
+            "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "drupal/helfi_yjdh",
     "type": "drupal-module",
+    "version": "0.0.1",
     "autoload": {
         "psr-4": {
             "Drupal\\HelfiYjdh\\": "src/"

--- a/helfi_yjdh.info.yml
+++ b/helfi_yjdh.info.yml
@@ -2,5 +2,4 @@ name: Helfi YJDH
 type: module
 description: Integrates YJDH service to Drupal
 package: Custom
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10

--- a/helfi_yjdh.module
+++ b/helfi_yjdh.module
@@ -8,4 +8,3 @@
  * This file is no longer required in Drupal 8.
  * @see https://www.drupal.org/node/2217931
  */
-

--- a/src/YjdhClient.php
+++ b/src/YjdhClient.php
@@ -93,6 +93,10 @@ class YjdhClient {
    *
    * @param \GuzzleHttp\ClientInterface $http_client
    *   The HTTP client.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger channel factory.
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $tempstore
+   *   Access to session storage.
    */
   public function __construct(
     ClientInterface $http_client,


### PR DESCRIPTION
# [AU-2123](https://helsinkisolutionoffice.atlassian.net/browse/AU-2123)

## What was done

## How to install
* Follow instructions in this PR: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1241
* Install test branches for all updated modules:
  *  `composer require drupal/helfi_atv:dev-AU-2123-d10-updates drupal/helfi_helsinki_profiili:dev-AU-2123-d10-updates drupal/helfi_yjdh:dev-AU-2123-d10-updates`

## How to test
* [ ] You should no longer get a warning about these incompatible modules when you run `drush updb` for example on the D10 branch
* [ ] Check that code follows our standards
* [ ] Run `make test-pw` just in case

## Automatic- / Regression tests
* [X] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
* https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1241
* https://github.com/City-of-Helsinki/drupal-module-helfi-atv/pull/28
* https://github.com/City-of-Helsinki/drupal-module-helfi-helsinki-profiili/pull/25

[AU-2123]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ